### PR TITLE
feat: Add account state check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -127,9 +127,9 @@
       }
     },
     "node_modules/@cybrid/cybrid-api-bank-typescript": {
-      "version": "0.31.4",
-      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-typescript/-/cybrid-api-bank-typescript-0.31.4.tgz",
-      "integrity": "sha512-CmU3K73z1f5Rqj4rgdwlGXw/ZXUeqp/e4FiFb0GhsoKWtpxyQ/yoKmrTDwgpSpq0ymP95+oV4Dd9RC3D7hfj2Q==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-typescript/-/cybrid-api-bank-typescript-0.33.0.tgz",
+      "integrity": "sha512-2Q4JizQDMOQy917KLmgoWNZ6oLuQNBQoK/MzkUPG1D13dz2uHy8QqbCw7kptSgji6+REpcwkV6evFyiwA4Hgjw==",
       "dependencies": {
         "rxjs": "^7.2.0"
       }
@@ -3905,9 +3905,9 @@
       }
     },
     "@cybrid/cybrid-api-bank-typescript": {
-      "version": "0.31.4",
-      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-typescript/-/cybrid-api-bank-typescript-0.31.4.tgz",
-      "integrity": "sha512-CmU3K73z1f5Rqj4rgdwlGXw/ZXUeqp/e4FiFb0GhsoKWtpxyQ/yoKmrTDwgpSpq0ymP95+oV4Dd9RC3D7hfj2Q==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@cybrid/cybrid-api-bank-typescript/-/cybrid-api-bank-typescript-0.33.0.tgz",
+      "integrity": "sha512-2Q4JizQDMOQy917KLmgoWNZ6oLuQNBQoK/MzkUPG1D13dz2uHy8QqbCw7kptSgji6+REpcwkV6evFyiwA4Hgjw==",
       "requires": {
         "rxjs": "^7.2.0"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,15 @@ function main() {
     );
   };
 
+  const pollAccount = (guid: string) => {
+    const evalFunc = (account: cybrid.AccountBankModel) => {
+      const state = account.state!;
+      const expectedState = cybrid.AccountBankModelStateEnum.Created;
+      return state === expectedState;
+    };
+    return poll(getAccount(guid), evalFunc, Config.TIMEOUT);
+  };
+
   const createQuote = (
     customer: cybrid.CustomerBankModel,
     side: cybrid.PostQuoteBankModelSideEnum,
@@ -271,6 +280,7 @@ function main() {
   // Create Account pipeline, requires Create Customer
   const createAccountObs = createCustomerObs.pipe(
     switchMap(customer => createAccount(customer)),
+    switchMap(account => pollAccount(account.guid!)),
     share()
   );
 


### PR DESCRIPTION
### Type of change

Feature

### Linked issue

Not tracked

### Why

Account's now have a state associated with them, which should be checked before attempting to create quotes and trades.

### How

Add account state check, similar to the identity record checks being performed.
